### PR TITLE
fix setting session TTL (ioredis)

### DIFF
--- a/src/lib/providers/ioredis.ts
+++ b/src/lib/providers/ioredis.ts
@@ -80,7 +80,7 @@ export class IoRedisSessionStore {
 		sessionData: any,
 		userId: string
 	): Promise<{ data: any; error: boolean; message: string }> => {
-		let sessionKey = this.uniqueIdGenerator();
+		let sessionKey = getSessionKey(this.sessionPrefix, this.uniqueIdGenerator());
 
 		let serializedSessionData;
 		try {
@@ -90,8 +90,9 @@ export class IoRedisSessionStore {
 			return formattedReturn(null, true, 'Unable to stringify session data.');
 		}
 		const redisPipeline = this.redisClient.pipeline();
-		redisPipeline.set(getSessionKey(this.sessionPrefix, sessionKey), serializedSessionData);
-		redisPipeline.sadd(getUserSessionKey(this.userSessionsPrefix, userId), getSessionKey(this.sessionPrefix, sessionKey));
+		redisPipeline.set(sessionKey, serializedSessionData);
+		redisPipeline.sadd(getUserSessionKey(this.userSessionsPrefix, userId), sessionKey);
+
 		if (this.useTTL && this.ttlSeconds) {
 			redisPipeline.expire(sessionKey, this.ttlSeconds);
 		}

--- a/src/lib/providers/ioredis.ts
+++ b/src/lib/providers/ioredis.ts
@@ -80,7 +80,7 @@ export class IoRedisSessionStore {
 		sessionData: any,
 		userId: string
 	): Promise<{ data: any; error: boolean; message: string }> => {
-		let sessionKey = getSessionKey(this.sessionPrefix, this.uniqueIdGenerator());
+		let sessionKey = this.uniqueIdGenerator();
 
 		let serializedSessionData;
 		try {
@@ -90,11 +90,10 @@ export class IoRedisSessionStore {
 			return formattedReturn(null, true, 'Unable to stringify session data.');
 		}
 		const redisPipeline = this.redisClient.pipeline();
-		redisPipeline.set(sessionKey, serializedSessionData);
-		redisPipeline.sadd(getUserSessionKey(this.userSessionsPrefix, userId), sessionKey);
-
+		redisPipeline.set(getSessionKey(this.sessionPrefix, sessionKey), serializedSessionData);
+		redisPipeline.sadd(getUserSessionKey(this.userSessionsPrefix, userId), getSessionKey(this.sessionPrefix, sessionKey));
 		if (this.useTTL && this.ttlSeconds) {
-			redisPipeline.expire(sessionKey, this.ttlSeconds);
+			redisPipeline.expire(getSessionKey(this.sessionPrefix, sessionKey), this.ttlSeconds);
 		}
 		await redisPipeline.exec();
 		if (this.signedCookies) {

--- a/src/lib/providers/ioredis.ts
+++ b/src/lib/providers/ioredis.ts
@@ -28,18 +28,18 @@ export class IoRedisSessionStore {
 	private readonly cookieOptions: CookieSerializeOptions;
 
 	constructor({
-		redisClient,
-		secret,
-		cookieName = 'session',
-		sessionPrefix = 'sk_ioredis_session',
-		userSessionsPrefix = 'sk_ioredis_user_sessions',
-		signed = true,
-		useTTL = true,
-		renewSessionBeforeExpire = false,
-		renewBeforeSeconds = defaultRenewBeforeSeconds,
-		serializer = JSON,
-		cookiesOptions = {}
-	}: ioRedisSessionOptions) {
+					redisClient,
+					secret,
+					cookieName = 'session',
+					sessionPrefix = 'sk_ioredis_session',
+					userSessionsPrefix = 'sk_ioredis_user_sessions',
+					signed = true,
+					useTTL = true,
+					renewSessionBeforeExpire = false,
+					renewBeforeSeconds = defaultRenewBeforeSeconds,
+					serializer = JSON,
+					cookiesOptions = {}
+				}: ioRedisSessionOptions) {
 		if (!redisClient) {
 			throw new Error('A pre-initiated redis client must be provided to the RedisStore');
 		}
@@ -89,11 +89,13 @@ export class IoRedisSessionStore {
 			console.log('Error in Set Session while serializing', er);
 			return formattedReturn(null, true, 'Unable to stringify session data.');
 		}
+
+		const prefixedSessionKey = getSessionKey(this.sessionPrefix, sessionKey);
 		const redisPipeline = this.redisClient.pipeline();
-		redisPipeline.set(getSessionKey(this.sessionPrefix, sessionKey), serializedSessionData);
-		redisPipeline.sadd(getUserSessionKey(this.userSessionsPrefix, userId), getSessionKey(this.sessionPrefix, sessionKey));
+		redisPipeline.set(prefixedSessionKey, serializedSessionData);
+		redisPipeline.sadd(getUserSessionKey(this.userSessionsPrefix, userId), sessionKey);
 		if (this.useTTL && this.ttlSeconds) {
-			redisPipeline.expire(getSessionKey(this.sessionPrefix, sessionKey), this.ttlSeconds);
+			redisPipeline.expire(prefixedSessionKey, this.ttlSeconds);
 		}
 		await redisPipeline.exec();
 		if (this.signedCookies) {
@@ -111,8 +113,10 @@ export class IoRedisSessionStore {
 		} = await validateCookie(cookies, this.cookieName, this.secret, this.signedCookies);
 		if (error) return formattedReturn(sessionId, error, message);
 		const sessionData = await this.redisClient.get(getSessionKey(this.sessionPrefix, sessionId));
+
 		if (!sessionData)
 			return formattedReturn(null, true, `Unable to find data for the provided key - ${sessionId}`);
+
 		let parsedSession;
 		try {
 			parsedSession = this.serializer.parse(sessionData);
@@ -158,7 +162,7 @@ export class IoRedisSessionStore {
 	};
 	// till here
 
-	deleteSession = async (cookies: Cookies) => {
+	deleteSession = async (cookies: Cookies, userId = null) => {
 		const {
 			data: sessionId,
 			error,
@@ -168,8 +172,19 @@ export class IoRedisSessionStore {
 			console.log('Error in delSession method', message);
 			return formattedReturn(sessionId, error, 'Unable to validate key while deleting');
 		}
-		const deleteData = await this.redisClient.del(getSessionKey(this.sessionPrefix, sessionId));
-		if (!deleteData) return formattedReturn(null, true, `Key not found while deleting`);
+		const prefixedSessionKey = getSessionKey(this.sessionPrefix, sessionId);
+		const sessionData = await this.redisClient.get(prefixedSessionKey);
+		if (!sessionData) return formattedReturn(sessionId, true, `Not a valid session key`);
+
+		if (userId) {
+			const redisPipeline = this.redisClient.pipeline();
+			redisPipeline.del(prefixedSessionKey);
+			redisPipeline.srem(getUserSessionKey(this.userSessionsPrefix, userId), sessionId);
+			await redisPipeline.exec()
+		} else {
+			await this.redisClient.del(prefixedSessionKey);
+		}
+
 		await this.deleteCookie(cookies);
 		return formattedReturn(sessionId, false, `Key successfully deleted`); // Returns unique key without prefix which is deleted from redis
 	};


### PR DESCRIPTION
`redisPipeline.expire` was just using the generated unique ID instead of the actual session key as prefix + unique id, resulting in TTL always being -1. I changed the assignment of `sessionKey` to be the prefix + id at the beginning of the function.

This is just for the `IoRedisSessionStore` since that's what I'm using at the moment, I'm not sure if the other Upstash/Redis client versions internally check the key/value pair and set the TTL accordingly themselves so I didn't make changes to them.