### PR TITLE
Vite 6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
 	},
 	"exports": {
 		".": {
+			"import": "./dist/index.js",
+			"require": "./dist/index.js",
+			"default": "./dist/index.js",
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}


### PR DESCRIPTION
In order to resolve the error:

```
[commonjs--resolver] Failed to resolve entry for package "@ethercorps/sveltekit-redis-session". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "@ethercorps/sveltekit-redis-session" package
```

"import" and "require" tell bundlers like Vite or Node how to resolve imports for both ESM and CJS.

"default" covers environments expecting that fallback.